### PR TITLE
fix(sync): LUSR v2 shadow persiste via burst Write (fix read-only prod 2026-07-03)

### DIFF
--- a/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
+++ b/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
@@ -1,9 +1,10 @@
 # PLAN HOTFIX — LUSR v2 shadow écrit sur un attach read-only (prod, régression 2026-07-03)
 
-> Statut : PRÊT — exécutable par une session agent autonome (Opus), AUCUN contexte
-> conversationnel requis : tout est dans ce fichier. Exécution sous contrat du skill
-> `plan-execution` (ordre strict, une phase à la fois, gates exacts, statuts
-> [x]/[~]/[!], zéro fix hors périmètre — consigner en §Découvertes).
+> Statut : **H1-H4 COMPLÉTÉS (2026-07-10)** ; **H5 EN ATTENTE — GATE USER** (merge main =
+> deploy prod auto, GO explicite requis) ; H6/H7 dépendent du deploy. Branche
+> `hotfix/lusr-shadow-ro` poussée (5 commits) ; **PR #53** ouverte vers main, CI 13/14
+> verte (seul E2E Playwright pending, frontend, sans lien avec ce diff Go-only).
+> Exécution sous contrat du skill `plan-execution`.
 >
 > **Branche : `hotfix/lusr-shadow-ro` créée depuis `origin/main`** (PAS depuis
 > `refactor/audits-2026-07` — la branche d'audits n'est pas mergée et son arborescence
@@ -231,8 +232,16 @@ sync 80.2s, skill 1.1s, v2 13.2s) ; tableau H3.4 rempli.
 
 ### H5 — Livraison (GATE USER — ne pas franchir sans GO explicite)
 
-- [ ] H5.1 Présenter au user : diff résumé, résultats des gates, rappel « push main =
-      deploy prod auto ». ATTENDRE le GO dans le tour courant.
+> **EN ATTENTE DU GO UTILISATEUR (2026-07-10).** L'agent autonome s'arrête ici : H5.2/H5.3
+> exigent le merge/push main = deploy prod AUTOMATIQUE, qui requiert un GO explicite de
+> l'utilisateur dans le tour courant (non acquis d'une session précédente — protocole H5).
+> Présentation faite via **PR #53** (diff résumé + gates + rappel deploy) + rapport final
+> de session. CI de branche 13/14 verte (E2E Playwright pending, frontend). H6/H7 (vérif
+> post-deploy VPS lecture seule + clôture + git mv vers `.ai/V7/`) s'exécutent APRÈS le
+> deploy. NE PAS clôturer (git mv + COMPLÉTÉ) tant que H5-H7 ne sont pas verts.
+
+- [~] H5.1 Présentation faite (PR #53 + rapport final). ATTENTE du GO utilisateur pour
+      H5.2/H5.3 — [~] car le GO n'est pas acquis en session autonome (référence : gate user).
 - [ ] H5.2 Après GO : merge dans main (se placer sur main à jour, merger la branche,
       pousser — jamais de push direct branche→main sans synchroniser main local).
 - [ ] H5.3 Surveiller le déploiement (conteneur redéployé, `docker ps` healthy,

--- a/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
+++ b/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
@@ -138,25 +138,37 @@ API `SharedAccess` (`internal/sync/shared_access.go`) :
 
 ### H2 — Implémentation (effort : moyen)
 
-- [ ] H2.1 Signatures + plombage (DC-H2) : `runLUSRV2Shadow(ctx, playerDB,
-      shared *SharedAccess, xuid, ownerOnlyPersist)` ; suppression du paramètre
-      `sharedDB *sql.DB` ; `shadowRunContext` transporte ce qu'il faut (handle du
-      burst courant passé aux étapes, pas stocké globalement).
-- [ ] H2.2 Découpage Read/Write (DC-H3) : sélection sous Read (release immédiat) ;
-      chunks sous `shared.Write(ctx, "lusr")` ; repos (`NewSkillV2Repo`,
-      `NewSquadOffsetRepo`) construits sur le handle du burst courant ;
-      `heldGroups`/watermark : sémantique INCHANGÉE (anti-gap 2026-06-07 préservé —
-      les tests existants le verrouillent).
-- [ ] H2.3 `runSkillRatingSteps` (DC-H4) : v1 + medal map sous Read, release, puis
-      `RunLUSRV2ShadowOwnerOnly(scoringCtx, playerDB, shared, e.xuid)` ; le
-      commentaire de classification est CORRIGÉ (doc inversée = anti-pattern n°9).
-- [ ] H2.4 Callers migrés (DC-H2) : `lusr_full_recompute.go`, `cmd/lusr_v2_replay`,
-      chemin H5 livesync de main, tests → `NewPinnedSharedAccess(db)`.
-- [ ] H2.5 Grep de contrôle : plus AUCUN appel `RunLUSRV2Shadow*(..., *sql.DB, ...)` ;
-      `go vet ./...` propre.
+- [x] H2.1 Signatures + plombage (DC-H2, ADAPTÉ interface seam §7) :
+      `runLUSRV2Shadow(ctx, playerDB *sql.DB, shared SharedAccessor, xuid, ownerOnlyPersist)` ;
+      suppression du paramètre `sharedDB *sql.DB`. Interface `SharedAccessor`
+      (Read/Write) déclarée côté `skill` (`skill_v2_shared_access.go`), satisfaite
+      structurellement par `*sync.SharedAccess`. `shadowRunContext.repo/squadRepo/sharedDB`
+      câblés PAR CHUNK sur le handle du burst (pas globalement).
+- [x] H2.2 Découpage Read/Write (DC-H3) : sélection sous `loadShadowMatchesUnderRead`
+      (Read, release immédiat) ; `processShadowChunk` par chunks de
+      `postsyncLUSRBurstChunk=3` sous `shared.Write(ctx, "lusr")` ; repos
+      `NewSkillV2Repo`/`NewSquadOffsetRepo` construits sur le handle du burst ;
+      `heldGroups`/watermark sémantique INCHANGÉE (map partagée entre chunks, ordre
+      chrono ASC préservé) ; 0 match candidat → AUCUN burst. Tests anti-gap/held/dual-row
+      existants restent verts (cf. gate).
+- [x] H2.3 `runSkillRatingSteps` (DC-H4) : v1 + medal map sous Read (helper
+      `runLUSRV1UnderRead`, defer release), PUIS `RunLUSRV2ShadowOwnerOnly(scoringCtx,
+      playerDB, shared, e.xuid)` (reçoit le `*SharedAccess`), PUIS sentinelle
+      (`runDualRowSentinelBestEffort`, playerDB-only). Commentaire de classification
+      CORRIGÉ (le v2 écrit shared → burst Write dédié). `runSkillRatingStepsWithDB`
+      SUPPRIMÉ (code mort).
+- [x] H2.4 Callers migrés : `engine_postsync_scoring.go` (passe `shared`),
+      `lusr_full_recompute.go` (`NewPinnedSharedAccess`), `cmd/lusr_v2_replay`,
+      `cmd/h5-lusr-smoke`, `cmd/lusr_v2_canonical_backfill` (`lusync.NewPinnedSharedAccess`),
+      `internal/games/halo_5/livesync/wire.go` (`syncpkg.NewPinnedSharedAccess`), ~21 sites
+      de test (`newPinnedSharedAccessor`, skill-local).
+- [x] H2.5 Grep de contrôle : plus AUCUN caller ne passe un `*sql.DB` brut au shadow
+      (build type-check garantit la signature `SharedAccessor`) ; `go vet ./...` propre.
 
-**Gate H2** : `cd apps/go-api && go build ./... && go vet ./...` verts ; test de repro
-H1.3 devenu VERT ; suite `go test ./internal/sync/...` verte.
+**Gate H2** : `cd apps/go-api && CGO_ENABLED=1 go build ./... && go vet ./...` verts (exit 0/0) ;
+suite `go test -tags=cgo ./internal/sync/...` verte (sync 24.5s, skill 0.8s, v2 13.3s, tous ok).
+Test de repro devenu VERT : couvert par la version pérenne H3.1 [~] (le repro a été retiré
+en H1 pour garder l'arbre buildable — cf. §7 adaptation).
 
 ### H3 — Tests et audit des segments frères (effort : moyen)
 

--- a/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
+++ b/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
@@ -172,28 +172,46 @@ en H1 pour garder l'arbre buildable — cf. §7 adaptation).
 
 ### H3 — Tests et audit des segments frères (effort : moyen)
 
-- [ ] H3.1 Pérenniser le test de repro (nom explicite, ex.
-      `TestLUSRV2Shadow_PersistsViaWriteBurst_WhenReadHandleIsReadOnly`) : lease burst
-      avec `read` = handle non-inscriptible et `acquire` = handle RW → run owner-only
-      traite et persiste ; assertion aussi sur l'avance du watermark.
-- [ ] H3.2 Test anti-deadlock : le shadow ne demande jamais un burst Write pendant
-      qu'un Read du même SharedAccess est en vol (le garde de `Write` transformerait
-      le bug en erreur — vérifier qu'aucun chemin ne la déclenche, y compris quand
-      `loadShadowMatches` retourne > 1 chunk).
-- [ ] H3.3 Non-régression : suite shadow complète
-      (`go test ./internal/sync/ -run "LUSR|Shadow"` + intégration ciblée) — les tests
-      d'autonomie owner-only / anti-gap / dual-row restent verts.
-- [ ] H3.4 AUDIT des autres segments lecture du post-sync sur main : pour chaque
-      `shared.Read(` de `engine_postsync*.go`, vérifier sur pièces que le bloc
-      n'appelle AUCUN chemin qui écrit shared (events/weapons = bursts Write, OK
-      constaté ; bloc intensités/scoring L22 : vérifier où écrivent les résultats).
-      Consigner le verdict par segment ICI (tableau). Toute anomalie trouvée = la
-      corriger dans CE hotfix seulement si c'est le même défaut de classification ;
-      sinon §Découvertes.
+- [x] H3.1 Test pérenne `TestLUSRV2Shadow_PersistsViaWriteBurst_WhenReadHandleIsReadOnly`
+      (`skill_v2_shadow_burst_test.go`) : `roRwSplitAccess` sur DB FICHIER — `Read` sert
+      un attach `READ_ONLY` (sélection OK), `Write` un attach RW (persist OK). Run
+      owner-only → `processed=1`, `writeCalls>=1`, état owner persisté avec
+      `last_match_at` non NULL (watermark avancé). VERT. Garde de régression : le handle
+      Read est réellement read-only → tout retour au persist-via-Read casserait le test.
+- [x] H3.2 Test anti-deadlock `TestLUSRV2Shadow_ReleasesReadBeforeWriteBurst_MultiChunk` :
+      `orderTrackingAccess` échoue si un `Write` est demandé pendant qu'un `Read` est en
+      vol. Sur 4 matchs (2 chunks) → `processed=4`, `writeCalls>=2`, `violation=""`. VERT.
+- [x] H3.3 Non-régression : suite complète `go test -tags=cgo ./internal/sync/skill/`
+      VERTE (0.85s) — owner-only / anti-gap / held-group / dual-row / canonical / h5
+      title-aware tous verts. `./internal/sync/...` vert (cf. H2).
+- [x] H3.4 AUDIT des segments lecture d'`engine_postsync*.go` (verdict par segment) :
 
-**Gate H3** : `go test ./...` (racine apps/go-api) vert ;
-`go test -tags=integration -p 1 -timeout 900s ./...` exit 0 (OBLIGATOIRE — sync/persist
-touchés ; jamais de commandes go concurrentes sur ce poste) ; tableau H3.4 rempli.
+      | Segment (`shared.Read`/`withSharedRead`) | Callee | Écrit shared ? | Verdict |
+      |---|---|---|---|
+      | pré-checks (postsync.go:81) | `hasMatchesNeedingScoreRefresh`, `hasConvergenceBacklog` | non (lectures) | OK |
+      | scoring (scoring.go:22) | `runScoringStepsWithDB` (perf/engagement/sessions/bot) | non — écrit PLAYER ; intensités ACCUMULÉES puis flushées en burst `Write("engagement_intensity")` (scoring.go:37) | OK |
+      | LUSR v1 (scoring.go:186) | `runLUSRV1UnderRead`→`batchComputeLUSR` | non — écrit PLAYER (`match_skill_rank`) | OK |
+      | enrichment_rows (postsync.go:217) | `ensurePlayerEnrichmentRows` | non — INSERT PLAYER `player_match_enrichment` | OK |
+      | events_select (260) | `selectMatchesMissingEvents` | non ; converge en burst `Write("events")` (276) | OK |
+      | weapons_select (302) | `selectMatchesMissingWeapons` | non ; converge en burst `Write("weapons")` (315) | OK |
+      | catalog_refresh (382) | `CatalogRefreshFromRegistry(metaDB, sharedDB)` | non — LIT `sharedDB` (match_registry), ÉCRIT `metadataDB` (playlists/maps/variants catalog) | OK (vérifié sur pièces catalog_refresh.go:60/89) |
+      | citations (396) | `runPostSyncCitations` | non — écrit PLAYER (`match_citations`) | OK |
+      | dominance (420) | `BackfillDominanceFlags` | non — écrit PLAYER via `PostSyncEnrichmentPersister` (commentaire L418) | OK |
+      | friends (471) | `RecomputeIsWithFriendsCore` | non — écrit PLAYER (`is_with_friends`) | OK |
+      | snapshot_readiness (511) | `EvaluateSnapshotReadiness` | non — écrit PLAYER (marqueur readiness) | OK |
+
+      Vérification transverse : grep `sharedDB.ExecContext` sur les .go de prod → seuls
+      écrivains shared = `csr_shared_writes` (via `runCSRSnapshotSync`, writer AUTONOME hors
+      segment Read), `engagement.go:559` (`persistMatchIntensities`, appelé SOUS le burst
+      `Write`), `pve.go` (pipeline PVE distinct), `backfill_registry_names`/`lusr_full_recompute`
+      (CLI/recovery, writer tenu). AUCUN dans un segment Read post-sync. Le shadow LUSR v2
+      était le SEUL écrivain shared mal classé « lecture » — corrigé. Aucune anomalie
+      résiduelle → §Découvertes = aucune sur ce point.
+
+**Gate H3** : VERT. `go test ./...` (racine) exit 0 (aucun échec) ;
+`go test -tags=integration -p 1 -timeout 900s ./...` exit 0 ; intégration ciblée
+`./internal/persist/... ./internal/sync/...` (anti-ART) exécutée et verte (persist 13.4s,
+sync 80.2s, skill 1.1s, v2 13.2s) ; tableau H3.4 rempli.
 
 ### H4 — Gate final pré-livraison (effort : rapide)
 

--- a/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
+++ b/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
@@ -215,13 +215,19 @@ sync 80.2s, skill 1.1s, v2 13.2s) ; tableau H3.4 rempli.
 
 ### H4 — Gate final pré-livraison (effort : rapide)
 
-- [ ] H4.1 `make go-api-lint` : 0 nouvelle erreur vs baseline.
-- [ ] H4.2 Skill `delivery-checklist` passé ; entrée `thought_log.md` (obligatoire
-      avant commit final).
-- [ ] H4.3 Commits propres sur `hotfix/lusr-shadow-ro` (messages
-      `fix(sync): ...` explicites), CI de branche verte si disponible.
+- [x] H4.1 `golangci-lint run --new-from-rev=28146aa3a` sur tous les packages modifiés
+      (sync/..., 3 cmd, livesync) = **0 issues** (0 nouvelle erreur vs baseline). Une
+      seule issue introduite (`processShadowChunk` 8 args > max 7) CORRIGÉE en repliant
+      `squadEnabled` dans `shadowRunContext` + `withGameplayDur` calculé dans l'appelant
+      (→ 6 args). `make go-api-lint` (go vet domain/analysis) inchangé.
+- [x] H4.2 Skill `delivery-checklist` passé : Go tests/vet/intégration verts ; logging
+      slog structuré (aucun `fmt.Println`/`log.Printf`/`t.Skip` introduit) ; code mort
+      supprimé (`runSkillRatingStepsWithDB`) ; capability-gated ; frontend N/A (aucun
+      changement web). Entrées `thought_log.md` par phase.
+- [x] H4.3 5 commits propres sur `hotfix/lusr-shadow-ro` (`fix(sync)`/`test(sync)`/
+      `docs`), poussés ; CI de branche vérifiée après push (cf. thought_log H4).
 
-**Gate H4** : tous les items H1→H4 statués ; aucun `[ ]` restant.
+**Gate H4** : tous les items H1→H4 statués ; aucun `[ ]` restant dans H1-H4.
 
 ### H5 — Livraison (GATE USER — ne pas franchir sans GO explicite)
 

--- a/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
+++ b/.ai/PLAN_HOTFIX_LUSR_SHADOW_RO_2026-07.md
@@ -103,19 +103,35 @@ API `SharedAccess` (`internal/sync/shared_access.go`) :
 
 ### H1 — Préparation et vérification sur pièces (effort : rapide)
 
-- [ ] H1.1 `git fetch origin && git checkout -b hotfix/lusr-shadow-ro origin/main`.
-- [ ] H1.2 Vérifier sur pièces (la topologie main ≠ branche audits) : localisation
-      réelle de `runSkillRatingSteps` / `runSkillRatingStepsWithDB`
-      (`engine_postsync_scoring.go`), `runLUSRV2Shadow` + `persistComputedMatchSkillV2`
-      (`skill_v2_shadow.go`), `SharedAccess` (`shared_access.go`),
-      `postsyncEventsBurstChunk` (valeur), tous les callers de
-      `RunLUSRV2Shadow(OwnerOnly)?` (`grep -rn "RunLUSRV2Shadow" apps/go-api`).
-      Consigner les chemins/lignes constatés ici.
-- [ ] H1.3 Reproduire le symptôme en local AVANT fix : test d'intégration provisoire
-      ou scénario existant adapté — un `SharedAccess` burst dont `read` sert un handle
-      où `shared_matches_v2` n'est pas inscriptible → `UpsertState` échoue avec le
-      message de prod. (Ce test devient le test pérenne en H3 — rouge ici, vert
-      après H2.)
+- [x] H1.1 Branche `hotfix/lusr-shadow-ro` déjà créée depuis `origin/main` (HEAD
+      `28146aa3a`, qui contient le merge audits) et checkoutée. Vérifié
+      `git branch --show-current` = `hotfix/lusr-shadow-ro`.
+- [x] H1.2 Vérifié sur pièces (topologie RÉELLE = sous-package, cf. §7 déviation) :
+      - `runSkillRatingSteps` / `runSkillRatingStepsWithDB` : `internal/sync/engine_postsync_scoring.go`
+        L135 / L151 (package `sync`). Caller : `engine_postsync.go:438`.
+      - `runLUSRV2Shadow` + `RunLUSRV2Shadow` + `RunLUSRV2ShadowOwnerOnly` +
+        `persistComputedMatchSkillV2` : `internal/sync/skill/skill_v2_shadow.go`
+        (L83 / L102 / L106 / L695) — **package `skill`**, pas `sync`.
+      - `SharedAccess` (+ `NewPinnedSharedAccess`, `Read`, `Write`) :
+        `internal/sync/shared_access.go` (package `sync`, L42/L69/L90/L118). Méthodes
+        exactement `Read(ctx)(*sql.DB,func(),error)` + `Write(ctx,string)(*sql.DB,func(),error)`
+        → `*sync.SharedAccess` satisfait structurellement l'interface `skill.SharedAccessor`.
+      - `postsyncEventsBurstChunk = 3` : `internal/sync/engine.go:50` (package `sync`).
+        → nouvelle constante `postsyncLUSRBurstChunk = 3` déclarée côté `skill` (pas
+        d'accès cross-package).
+      - Callers de `RunLUSRV2Shadow(OwnerOnly)?` : engine_postsync_scoring.go:194 (fix),
+        lusr_full_recompute.go:46, cmd/lusr_v2_replay:89, cmd/h5-lusr-smoke:67,
+        cmd/lusr_v2_canonical_backfill:110, internal/games/halo_5/livesync/wire.go:107,
+        + ~20 sites de test dans internal/sync/skill/skill_v2_shadow_test.go &
+        skill_v2_capability_test.go. Re-exports : skill_reexport.go:101/117.
+- [x] H1.3 Repro observé ROUGE contre l'ANCIENNE signature (handle unique) : DB fichier
+      seedée (1 match 2v2 éligible), attachée READ_ONLY (`ATTACH ... (READ_ONLY); USE s`),
+      passée à `RunLUSRV2Shadow(ctx, nil, roHandle, "owner")`. Résultat : `loadShadowMatches`
+      + `LoadState` OK (SELECT), `persistComputedMatchSkillV2` → `UpsertState` échoue
+      `Cannot execute statement of type "INSERT" on database "s" which is attached in
+      read-only mode!` → `processed=0`, aucune ligne `player_skill_state_v2` écrite
+      (message prod reproduit). La version pérenne VERTE (accès scindé) est livrée en
+      H3.1 (cf. §7 adaptation).
 
 **Gate H1** : chemins consignés ; test de repro ROUGE avec l'erreur
 `read-only`/non-inscriptible attendue.
@@ -234,4 +250,22 @@ précédente.
 
 ## 7. Découvertes hors périmètre
 
-- (vide)
+- **DÉVIATION MAJEURE DE TOPOLOGIE (constatée 2026-07-10, sur pièces)** : contrairement
+  à l'hypothèse de l'en-tête du plan (« sur main tout est encore à plat dans
+  `internal/sync/` »), la branche `hotfix/lusr-shadow-ro` a été créée depuis un
+  `origin/main` qui **contient déjà le merge de la campagne audits** (commit
+  `28146aa3a`, déployé prod 2026-07-10). La topologie réelle = celle de la branche
+  audits : le cluster skill (dont `RunLUSRV2Shadow`) vit dans le **sous-package**
+  `internal/sync/skill/` (package `skill`), ré-exporté vers `sync` via
+  `skill_reexport.go`. `SharedAccess` reste dans package `sync`
+  (`internal/sync/shared_access.go`). Le sous-package `skill` NE PEUT PAS importer
+  `sync` (cycle sync→skill). Conséquence : DC-H2 est appliqué via l'**interface seam**
+  décrit en H7.2 (petite interface `SharedAccessor` déclarée côté `skill`, satisfaite
+  STRUCTURELLEMENT par `*sync.SharedAccess`), et NON par passage direct d'un
+  `*sync.SharedAccess` au runner. H7.2 (report du fix sur la branche audits) devient
+  **sans objet** : la branche audits est déjà mergée dans main. Voir thought_log
+  2026-07-10.
+- Adaptation du test de repro (H1.3) : la topologie sous-package impose que la version
+  pérenne du test utilise la nouvelle API (`SharedAccessor`). Le repro ROUGE est observé
+  contre l'ANCIENNE signature (handle unique RO), puis la version pérenne VERTE (accès
+  scindé Read RO / Write RW) est livrée en H2/H3 — même intention, API adaptée.

--- a/.ai/thought_log.md
+++ b/.ai/thought_log.md
@@ -1,3 +1,29 @@
+## [2026-07-10] HOTFIX LUSR shadow read-only — H3 (tests + audit segments frères)
+
+**Statut** : En cours (phase H3 close ; H4 lint + delivery à suivre).
+
+**Décision principale** : 2 tests pérennes (`skill_v2_shadow_burst_test.go`) verrouillent le
+fix. (1) `TestLUSRV2Shadow_PersistsViaWriteBurst_WhenReadHandleIsReadOnly` : DB FICHIER,
+`roRwSplitAccess` — Read = attach READ_ONLY (sélection), Write = attach RW (persist) → le
+handle Read est réellement read-only, donc tout retour au persist-via-Read casserait le test.
+(2) `TestLUSRV2Shadow_ReleasesReadBeforeWriteBurst_MultiChunk` : garde anti-deadlock (Write
+jamais demandé avec un Read en vol), 4 matchs = 2 chunks. DDL de schéma extrait en const
+`shadowSchemaDDL` (réutilisé in-memory + fichier). AUDIT H3.4 : chaque segment `shared.Read`/
+`withSharedRead` d'engine_postsync* vérifié sur pièces — aucun n'écrit le handle shared
+(catalog_refresh écrit metadataDB pas shared, vérifié ; les autres écrivent la PLAYER DB).
+Le shadow LUSR v2 était le SEUL écrivain shared mal classé « lecture ». Aucune anomalie
+résiduelle.
+
+**Résultats observés** : `go test ./...` (racine) exit 0 ; `go test -tags=integration -p 1`
+exit 0 ; intégration anti-ART ciblée verte (persist 13.4s, sync 80.2s). Les 2 tests pérennes
+verts ; suite skill complète verte.
+
+**Prochaine étape** : H4 — `make go-api-lint` (0 nouvelle erreur vs baseline),
+delivery-checklist, puis H5 = GATE USER (présenter le diff, attendre le GO avant merge main
+= deploy prod auto).
+
+---
+
 ## [2026-07-10] HOTFIX LUSR shadow read-only — H2 (implémentation)
 
 **Statut** : En cours (phase H2 close ; H3 tests + audit à suivre).

--- a/.ai/thought_log.md
+++ b/.ai/thought_log.md
@@ -1,3 +1,28 @@
+## [2026-07-10] HOTFIX LUSR shadow read-only — ARRÊT à H5 (GATE USER)
+
+**Statut** : H1-H4 COMPLÉTÉS ; H5 EN ATTENTE du GO utilisateur (merge main = deploy prod
+auto) ; H6/H7 après deploy. NON clôturé (pas de git mv vers V7 tant que H5-H7 non verts).
+
+**Décision principale** : la CI ne se déclenche PAS sur push d'une branche `hotfix/*`
+(ci.yml : `push branches [main, feature/*, refactor/*, fix/*, docs/*, chore/*]`) — j'ai
+donc ouvert **PR #53** vers main (déclenche `pull_request`) pour obtenir le signal CI SANS
+merger (le deploy n'a lieu qu'au push sur main). Ouvrir une PR ≠ deploy.
+
+**Résultats observés** : CI PR #53 = 13/14 jobs VERTS (Go Build+Test ubuntu+windows, Go
+Baseline non-régression, Go Coverage full ./... CGO, Go Lint golangci, Contract, Lease
+ADR 0013, OpenAPI, Frontend tsc+Vite, Docker Build, Permissions gosu, regen-demo, Syntaxe).
+Seul E2E React (Playwright) encore pending — frontend, sans lien avec ce diff Go-only.
+Aucun échec.
+
+**Prochaine étape (requiert l'utilisateur)** : GO explicite → merge `hotfix/lusr-shadow-ro`
+dans main (se placer sur main à jour, merger, push = deploy auto) → surveiller deploy
+(`docker ps` healthy, `/health` 200) → H6 vérif VPS lecture seule (plus de `persist état
+échoué`, writer RW retombé, plus de 503, backlog LUSR résorbé) → H7 clôture (statuer tout,
+git mv plan vers `.ai/V7/`, MAJ `PLAN_MONITORING_TRIAGE_DETECTIONS_2026-07.md` B1). Repli
+post-deploy : `LEVELUP_POSTSYNC_BURST=0` (mode pinned).
+
+---
+
 ## [2026-07-10] HOTFIX LUSR shadow read-only — H4 (lint + delivery-checklist)
 
 **Statut** : Complété (côté implémentation branche) ; reste H5 (GATE USER : merge main =

--- a/.ai/thought_log.md
+++ b/.ai/thought_log.md
@@ -1,3 +1,24 @@
+## [2026-07-10] FIX RankCatalog nil-safe — panic boot mode démo (E2E PR #53 rouge)
+
+**Statut** : Complété (superviseur de campagne, hors plan LUSR — fix de gate CI).
+
+**Décision technique principale** : l'E2E Playwright de la PR #53 échouait 2× (~37 min) :
+le backend PANIQUE au boot en mode démo (`RankCatalog.Len()` nil deref, ranks.go:67,
+appelé par buildTitleRuntime server.go:379). Cause : metadata.duckdb absente en démo CI →
+`rank_catalog_meta_db_open_failed` (chemin best-effort prévu) → hiRanks reste nil → le
+slog `adapter_loaded` appelle hiRanks.Len(). Bug PRÉ-EXISTANT sur main (chantier
+leaderboard/catalogue, E2E skipped sur main donc jamais vu) — vérifié : la PR #53 ne
+touche ni server.go ni ranks.go. Fix : méthodes de *RankCatalog nil-safe (nil = catalog
+vide, contrat documenté sur le type) + test TestRankCatalog_NilReceiverBehavesAsEmpty.
+Porté par la branche hotfix/lusr-shadow-ro pour débloquer son propre gate E2E.
+
+**Résultats observés** : gofmt/vet/test mappings = 0 ; le panic ne peut plus se produire
+(tous les accès byID gardés).
+
+**Conclusion / prochaine étape** : rerun E2E sur la PR #53 ; si vert → GO merge utilisateur.
+
+---
+
 ## [2026-07-10] HOTFIX LUSR shadow read-only — ARRÊT à H5 (GATE USER)
 
 **Statut** : H1-H4 COMPLÉTÉS ; H5 EN ATTENTE du GO utilisateur (merge main = deploy prod

--- a/.ai/thought_log.md
+++ b/.ai/thought_log.md
@@ -1,3 +1,30 @@
+## [2026-07-10] HOTFIX LUSR shadow read-only — H1 (prep + repro ROUGE)
+
+**Statut** : En cours (phase H1 close ; H2 implémentation à suivre).
+
+**Décision principale** : hotfix de la régression prod 2026-07-03 (LUSR v2 shadow persiste
+`player_skill_state_v2` sur un attach shared read-only → ~6500 WARN/j, watermark figé,
+writer RW tenu, /health 503). DÉVIATION MAJEURE constatée sur pièces : la branche
+`hotfix/lusr-shadow-ro` part d'un `origin/main` qui contient DÉJÀ le merge audits
+(`28146aa3a`), donc le cluster skill (`RunLUSRV2Shadow`) est dans le sous-package
+`internal/sync/skill/` (pas « à plat » comme le supposait l'en-tête du plan). Le
+sous-package ne peut pas importer `sync` (cycle) → DC-H2 appliqué via l'INTERFACE SEAM de
+H7.2 (`skill.SharedAccessor` satisfaite structurellement par `*sync.SharedAccess`), pas
+par passage direct. H7.2 (report branche audits) devient sans objet (déjà mergée).
+
+**Résultats observés** : repro ROUGE fidèle contre l'ancienne signature (handle unique) :
+DB fichier seedée + attach READ_ONLY → `RunLUSRV2Shadow` retourne `processed=0` avec le
+message prod EXACT `persist état échoué — watermark non avancé ... Cannot execute statement
+of type "INSERT" on database "s" which is attached in read-only mode!`. Test de repro
+supprimé après capture (arbre buildable) ; version pérenne VERTE (accès scindé) en H3.1.
+
+**Prochaine étape** : H2 — interface `SharedAccessor` côté skill, signatures
+`runLUSRV2Shadow(ctx, playerDB, shared SharedAccessor, xuid, ownerOnly)`, découpage
+Read(sélection)/Write-burst(persist per-match chunké `postsyncLUSRBurstChunk=3`), migration
+de tous les callers (engine, lusr_full_recompute, 3 cmd, wire h5, ~20 tests).
+
+---
+
 ## [2026-07-10] MERGE MAIN — campagne audits 2026-07 + clôture + gate humain (GO utilisateur)
 
 **Statut** : En cours (merge exécuté dans cette session ; post-deploy VPS à suivre).

--- a/.ai/thought_log.md
+++ b/.ai/thought_log.md
@@ -1,3 +1,24 @@
+## [2026-07-10] HOTFIX LUSR shadow read-only — H4 (lint + delivery-checklist)
+
+**Statut** : Complété (côté implémentation branche) ; reste H5 (GATE USER : merge main =
+deploy prod auto) + H6/H7 (post-deploy, dépendent du deploy).
+
+**Décision principale** : `golangci-lint --new-from-rev=28146aa3a` = 0 issue sur tous les
+packages modifiés → aucune dette ajoutée. La seule issue introduite (`processShadowChunk`
+8 args > 7) corrigée en repliant `squadEnabled` dans `shadowRunContext` et en calculant
+`withGameplayDur` dans l'appelant (6 args, ne touche pas la logique s/heldGroups critique).
+delivery-checklist : logging slog OK, aucun `fmt.Println`/`t.Skip`, code mort supprimé,
+frontend N/A.
+
+**Résultats observés** : build 0, vet 0, `go test ./...` 0, intégration `-p 1` 0, lint
+new-from-rev 0. 5 commits sur la branche.
+
+**Prochaine étape** : H5 — présenter à l'utilisateur (diff + gates), ATTENDRE le GO
+explicite du tour courant AVANT tout merge/push main (= deploy prod auto). H6/H7 = vérif
+post-deploy VPS (lecture seule) + clôture, après le deploy.
+
+---
+
 ## [2026-07-10] HOTFIX LUSR shadow read-only — H3 (tests + audit segments frères)
 
 **Statut** : En cours (phase H3 close ; H4 lint + delivery à suivre).

--- a/.ai/thought_log.md
+++ b/.ai/thought_log.md
@@ -1,3 +1,30 @@
+## [2026-07-10] HOTFIX LUSR shadow read-only — H2 (implémentation)
+
+**Statut** : En cours (phase H2 close ; H3 tests + audit à suivre).
+
+**Décision principale** : interface seam `skill.SharedAccessor` (Read/Write) satisfaite
+structurellement par `*sync.SharedAccess` (sous-package skill ne peut pas importer sync).
+`runLUSRV2Shadow` réécrit : sélection sous `loadShadowMatchesUnderRead` (Read, release
+immédiat) → chunks de 3 (`postsyncLUSRBurstChunk`) sous `shared.Write(ctx,"lusr")`, repos
++ lectures per-match sur le handle du burst (persist va sur RW, plus jamais RO). 0 candidat
+→ aucun burst. `runSkillRatingSteps` (engine) découpé DC-H4 : v1 sous Read (helper), shadow
+v2 via bursts (reçoit le `*SharedAccess`), sentinelle playerDB-only ; `runSkillRatingStepsWithDB`
+supprimé ; commentaire de classification corrigé. Nouveau fichier `skill_v2_shared_access.go`
+(interface + pinned skill-local + 2 helpers) pour ne pas accroître skill_v2_shadow.go (déjà
+>500L) ; import `duckdb` retiré de skill_v2_shadow.go. Callers migrés : engine,
+lusr_full_recompute, 3 cmd, wire h5, ~21 tests.
+
+**Résultats observés** : `CGO_ENABLED=1 go build ./...` exit 0 ; `go vet ./...` exit 0 ;
+`go test -tags=cgo ./internal/sync/...` tous ok (sync 24.5s, skill 0.8s, v2 13.3s) — les
+tests anti-gap/held-group/dual-row/owner-only existants restent verts (sémantique watermark
+inchangée).
+
+**Prochaine étape** : H3 — test pérenne read-only VERT (accès scindé Read RO / Write RW,
+watermark avance), test anti-deadlock (Read relâché avant Write, incl. >1 chunk), audit des
+segments frères `shared.Read(` de engine_postsync*, gate intégration `-p 1`.
+
+---
+
 ## [2026-07-10] HOTFIX LUSR shadow read-only — H1 (prep + repro ROUGE)
 
 **Statut** : En cours (phase H1 close ; H2 implémentation à suivre).

--- a/apps/go-api/cmd/h5-lusr-smoke/main.go
+++ b/apps/go-api/cmd/h5-lusr-smoke/main.go
@@ -64,7 +64,7 @@ func main() {
 		fmt.Printf("reset state (non bloquant): %v\n", err)
 	}
 
-	processed, err := lusync.RunLUSRV2ShadowOwnerOnly(ctx, nil, shared, jgtmXUID)
+	processed, err := lusync.RunLUSRV2ShadowOwnerOnly(ctx, nil, lusync.NewPinnedSharedAccess(shared), jgtmXUID)
 	if err != nil {
 		fatal("RunLUSRV2ShadowOwnerOnly: %v", err)
 	}

--- a/apps/go-api/cmd/lusr_v2_canonical_backfill/main.go
+++ b/apps/go-api/cmd/lusr_v2_canonical_backfill/main.go
@@ -107,7 +107,7 @@ func main() {
 			playerDB = openDB(playerDBPath(*dataRoot, gt))
 		}
 
-		processed, err := lusync.RunLUSRV2ShadowOwnerOnly(ctx, playerDB, shared, xuid)
+		processed, err := lusync.RunLUSRV2ShadowOwnerOnly(ctx, playerDB, lusync.NewPinnedSharedAccess(shared), xuid)
 		if playerDB != nil {
 			playerDB.Close()
 		}

--- a/apps/go-api/cmd/lusr_v2_replay/main.go
+++ b/apps/go-api/cmd/lusr_v2_replay/main.go
@@ -86,7 +86,7 @@ func main() {
 			slog.Warn("xuid introuvable", "gamertag", gt)
 			continue
 		}
-		processed, err := lusync.RunLUSRV2Shadow(ctx, nil, db, xuid)
+		processed, err := lusync.RunLUSRV2Shadow(ctx, nil, lusync.NewPinnedSharedAccess(db), xuid)
 		if err != nil {
 			slog.Warn("RunLUSRV2Shadow", "gamertag", gt, "err", err)
 			continue

--- a/apps/go-api/internal/games/halo_5/livesync/wire.go
+++ b/apps/go-api/internal/games/halo_5/livesync/wire.go
@@ -104,7 +104,7 @@ func newHalo5Runner(cfg *config.AppConfig, gamertag, xuid string) *Runner {
 			}
 			// LUSR incrémental owner-only (gated capability via registre boot + env
 			// LUSR_V2 posés au boot serveur). Best-effort.
-			if _, lerr := syncpkg.RunLUSRV2ShadowOwnerOnly(runCtx, playerDB.SQLDb(), shared, xuid); lerr != nil {
+			if _, lerr := syncpkg.RunLUSRV2ShadowOwnerOnly(runCtx, playerDB.SQLDb(), syncpkg.NewPinnedSharedAccess(shared), xuid); lerr != nil {
 				slog.WarnContext(runCtx, "h5 post-score: LUSR incrémental échoué (non bloquant)",
 					"gamertag", gamertag, "err", lerr)
 			}

--- a/apps/go-api/internal/games/mappings/ranks.go
+++ b/apps/go-api/internal/games/mappings/ranks.go
@@ -45,6 +45,10 @@ func (e RankEntry) FullLabel(locale string) (string, bool) {
 //
 // L'ordre d'itération (Next) suit l'ordre numérique de `rank_id` qui correspond
 // à la progression de carrière côté Halo Waypoint.
+//
+// Un *RankCatalog nil est valide et se comporte comme un catalog vide : le
+// chargement est best-effort (metadata absente en mode démo / titre sans rangs)
+// et les consommateurs ne re-vérifient pas le pointeur.
 type RankCatalog struct {
 	titleSlug string
 	byID      map[int]RankEntry
@@ -61,13 +65,26 @@ func NewRankCatalog(titleSlug string, entries []RankEntry) *RankCatalog {
 }
 
 // TitleSlug retourne le slug du titre porteur du catalog.
-func (c *RankCatalog) TitleSlug() string { return c.titleSlug }
+func (c *RankCatalog) TitleSlug() string {
+	if c == nil {
+		return ""
+	}
+	return c.titleSlug
+}
 
 // Len retourne le nombre de rangs chargés.
-func (c *RankCatalog) Len() int { return len(c.byID) }
+func (c *RankCatalog) Len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.byID)
+}
 
 // Get retourne le RankEntry pour rank_id (ok = false si absent).
 func (c *RankCatalog) Get(id int) (RankEntry, bool) {
+	if c == nil {
+		return RankEntry{}, false
+	}
 	e, ok := c.byID[id]
 	return e, ok
 }
@@ -75,6 +92,9 @@ func (c *RankCatalog) Get(id int) (RankEntry, bool) {
 // Next retourne le rang suivant dans la progression (rank_id + 1).
 // Retourne (zero, false) si id est le dernier rang du catalog.
 func (c *RankCatalog) Next(id int) (RankEntry, bool) {
+	if c == nil {
+		return RankEntry{}, false
+	}
 	e, ok := c.byID[id+1]
 	return e, ok
 }
@@ -84,6 +104,9 @@ func (c *RankCatalog) Next(id int) (RankEntry, bool) {
 // cumulée au rang max (où la progression intra-rang est nulle). 0 si le catalog n'a
 // pas les seuils (XPRequired non chargé).
 func (c *RankCatalog) CumulativeXPRequired(uptoRankInclusive int) int {
+	if c == nil {
+		return 0
+	}
 	total := 0
 	for id := 1; id <= uptoRankInclusive; id++ {
 		if e, ok := c.byID[id]; ok {
@@ -96,6 +119,9 @@ func (c *RankCatalog) CumulativeXPRequired(uptoRankInclusive int) int {
 // FullLabel résout le libellé complet d'un rang dans la locale demandée.
 // Retourne ("", false) si rank_id est absent.
 func (c *RankCatalog) FullLabel(id int, locale string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
 	e, ok := c.byID[id]
 	if !ok {
 		return "", false
@@ -106,6 +132,9 @@ func (c *RankCatalog) FullLabel(id int, locale string) (string, bool) {
 
 // IDs retourne la liste triée des rank_id chargés (utile pour debug/tests).
 func (c *RankCatalog) IDs() []int {
+	if c == nil {
+		return nil
+	}
 	out := make([]int, 0, len(c.byID))
 	for id := range c.byID {
 		out = append(out, id)

--- a/apps/go-api/internal/games/mappings/ranks_test.go
+++ b/apps/go-api/internal/games/mappings/ranks_test.go
@@ -118,3 +118,33 @@ func TestRankCatalog_EmptyConstructor(t *testing.T) {
 		t.Errorf("IDs() devrait être vide")
 	}
 }
+
+// Un *RankCatalog nil doit se comporter comme un catalog vide : le chargement
+// est best-effort (metadata absente en mode démo) et buildTitleRuntime logge
+// ranks_count via Len() sans re-vérifier le pointeur (panic boot E2E 2026-07-10).
+func TestRankCatalog_NilReceiverBehavesAsEmpty(t *testing.T) {
+	t.Parallel()
+	var c *RankCatalog
+
+	if got := c.Len(); got != 0 {
+		t.Errorf("Len() sur nil = %d, want 0", got)
+	}
+	if got := c.TitleSlug(); got != "" {
+		t.Errorf("TitleSlug() sur nil = %q, want \"\"", got)
+	}
+	if _, ok := c.Get(1); ok {
+		t.Error("Get(1) sur nil : ok = true, want false")
+	}
+	if _, ok := c.Next(1); ok {
+		t.Error("Next(1) sur nil : ok = true, want false")
+	}
+	if got := c.CumulativeXPRequired(10); got != 0 {
+		t.Errorf("CumulativeXPRequired(10) sur nil = %d, want 0", got)
+	}
+	if _, ok := c.FullLabel(1, "fr"); ok {
+		t.Error("FullLabel(1) sur nil : ok = true, want false")
+	}
+	if got := c.IDs(); got != nil {
+		t.Errorf("IDs() sur nil = %v, want nil", got)
+	}
+}

--- a/apps/go-api/internal/sync/engine_postsync_scoring.go
+++ b/apps/go-api/internal/sync/engine_postsync_scoring.go
@@ -132,66 +132,35 @@ func (e *SyncEngine) runScoringStepsWithDB(ctx context.Context, playerDB, shared
 // title.CapLUSR (gate sur e.titleSlug, autoritatif côté engine) — un titre sans
 // CapLUSR saute proprement. Best-effort : chaque sous-étape logue + trackFatalErr
 // sur erreur sans interrompre le reste (idempotent).
+//
+// Découpage contention (fix read-only 2026-07-03) : le v1 LIT shared et écrit la
+// PLAYER DB → segment Read (release immédiat). Le v2 shadow, lui, écrit
+// player_skill_state_v2 CÔTÉ SHARED : il reçoit le *SharedAccess (pas un handle
+// de lecture) et fait ses PROPRES bursts Write. Le Read v1 est relâché AVANT →
+// aucun Read en vol quand le shadow demande son burst (garde anti-deadlock).
 func (e *SyncEngine) runSkillRatingSteps(ctx context.Context, playerDB *sql.DB, shared *SharedAccess, r *domain.PostSyncResult) {
-	// Étape 1 contention : LUSR LIT shared (repos SkillV2/SquadOffset) et écrit
-	// la PLAYER DB (match_skill_rank, skill_v2_shadow.go:69) — segment Read.
-	sharedDB, releaseRead, rerr := shared.Read(ctx)
-	if rerr != nil {
-		slog.WarnContext(ctx, "post-sync: LUSR — lecture shared indisponible, bloc skippé",
-			"gamertag", e.gamertag, "err", rerr)
-		trackFatalErr(r, "lusr shared read", rerr)
-		return
-	}
-	defer releaseRead()
-	e.runSkillRatingStepsWithDB(ctx, playerDB, sharedDB, r)
-}
-
-// runSkillRatingStepsWithDB : corps historique du bloc LUSR, inchangé — reçoit
-// un handle shared de LECTURE.
-func (e *SyncEngine) runSkillRatingStepsWithDB(ctx context.Context, playerDB, sharedDB *sql.DB, r *domain.PostSyncResult) {
-	lusrEnabled := slugHasLUSR(e.titleSlug)
-	if !lusrEnabled {
+	if !slugHasLUSR(e.titleSlug) {
 		slog.DebugContext(ctx, "post-sync: LUSR skippé — capability absente",
 			"gamertag", e.gamertag, "title_slug", e.titleSlug)
+		return
 	}
+	// 2. LUSR v1 (TrueSkill 2) sous segment Read (release immédiat).
+	e.runLUSRV1UnderRead(ctx, playerDB, shared, r)
 
-	// 2. LUSR v1 (TrueSkill 2 closed-form, formule composite).
-	// SKIPPÉ si LEVELUP_LUSR_CANONICAL=LUSR_V2 — alors v2 est canonical et
-	// écrit directement dans rating_type='LUSR' via Stratégie C.
-	if lusrEnabled && !IsLUSRV2Canonical() {
-		slog.DebugContext(ctx, "post-sync: calcul LUSR v1", "gamertag", e.gamertag)
-		medalMap := e.loadMedalExploitMapBestEffort(ctx, sharedDB)
-		if n, err := batchComputeLUSR(ctx, playerDB, sharedDB, e.xuid, medalMap, false); err != nil {
-			slog.WarnContext(ctx, "post-sync: LUSR v1 échoué", "gamertag", e.gamertag, "err", err)
-			trackFatalErr(r, "LUSR", err)
-		} else {
-			r.LUSRUpdated = n
-			slog.DebugContext(ctx, "post-sync: LUSR v1 mis à jour", "gamertag", e.gamertag, "count", n)
-		}
-	} else if lusrEnabled {
-		slog.DebugContext(ctx, "post-sync: LUSR v1 skippé (canonical=LUSR_V2)", "gamertag", e.gamertag)
-	}
-
-	// 2.5 LUSR v2 — shadow mode (LEVELUP_LUSR_V2_ENABLED=1). Calcule en parallèle
-	// du v1 et écrit dans player_skill_state_v2.
-	//
-	// Si LEVELUP_LUSR_CANONICAL=LUSR_V2, écrit AUSSI dans match_skill_rank
-	// (rating_type='LUSR' slot historique) via Stratégie C — l'UI voit alors
-	// le v2 sans modif des readers. Cf. ADR 0024. RunLUSRV2Shadow self-gate la
-	// capability ; le garde ici évite juste l'appel inutile.
-	if lusrEnabled && IsLUSRV2Enabled() {
+	// 2.5 LUSR v2 — shadow mode (LEVELUP_LUSR_V2_ENABLED=1). Reçoit le
+	// *SharedAccess : il persiste player_skill_state_v2 (côté shared) via ses
+	// propres bursts Write("lusr"). Ne JAMAIS lui passer un handle de lecture
+	// (régression read-only 2026-07-03). Si LEVELUP_LUSR_CANONICAL=LUSR_V2, écrit
+	// AUSSI match_skill_rank (Stratégie C, ADR 0024). RunLUSRV2ShadowOwnerOnly
+	// self-gate la capability ; le garde ici évite l'appel inutile.
+	if IsLUSRV2Enabled() {
 		// OWNER-ONLY (fix 2026-06-08) : le post-sync de CE joueur ne persiste/avance
 		// que SON propre état + watermark + ligne canonique, jamais ceux de ses
-		// coéquipiers. Sinon (persist 2 équipes) le sync d'un coéquipier avançait le
-		// watermark des autres → leur match partagé sautait à jamais sans ligne LUSR
-		// (couplage cross-joueur). Owner-only rend chaque sync AUTONOME : un joueur
-		// obtient ses lignes complètes seul, sans dépendre d'un backfill ni du sync
-		// d'un autre. Même chemin que le backfill recovery, déjà validé.
+		// coéquipiers (sinon couplage cross-joueur → matchs sautés sans ligne LUSR).
 		// Porte le titre de l'engine dans le ctx pour le seam LUSR title-aware
-		// (GetLUSRChainForTitle). Infinite → classifier défaut ; titres dédiés (h5)
-		// → leur classifier. Idempotent si le ctx le porte déjà.
+		// (GetLUSRChainForTitle : Infinite → classifier défaut ; h5 → dédié).
 		scoringCtx := ctxkeys.WithTitleSlug(ctx, e.titleSlug)
-		if n, err := RunLUSRV2ShadowOwnerOnly(scoringCtx, playerDB, sharedDB, e.xuid); err != nil {
+		if n, err := RunLUSRV2ShadowOwnerOnly(scoringCtx, playerDB, shared, e.xuid); err != nil {
 			slog.WarnContext(ctx, "post-sync: LUSR v2 shadow échoué",
 				"gamertag", e.gamertag, "err", err)
 		} else if n > 0 {
@@ -200,26 +169,61 @@ func (e *SyncEngine) runSkillRatingStepsWithDB(ctx context.Context, playerDB, sh
 		}
 	}
 
-	// 2.6 Sentinelle dual-row (Sprint 2.C) — SEULEMENT en mode canonical (sinon la
-	// table dual-row LUSR_V2 n'est pas censée exister). Détecte l'invariant
-	// Stratégie C cassé (match avec LUSR_V2 sans LUSR). Read-only, idempotente,
-	// timeout 30s pour ne jamais bloquer le post-sync. Toute incohérence →
-	// slog.ErrorContext (auto-routé logs/sync.log) ; pas de notif externe.
-	if lusrEnabled && IsLUSRV2Canonical() && playerDB != nil {
-		sentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		report, serr := RunDualRowSentinel(sentCtx, playerDB)
-		cancel()
-		switch {
-		case serr != nil:
-			slog.ErrorContext(ctx, "post-sync: sentinelle dual-row échouée",
-				"err", serr, "gamertag", e.gamertag)
-		case report.OnlyLUSRV2 > 0:
-			slog.ErrorContext(ctx, "post-sync: sentinelle dual-row a détecté des incohérences",
-				"gamertag", e.gamertag,
-				"only_lusr_v2", report.OnlyLUSRV2,
-				"sample", report.SampleInconsistent,
-			)
-		}
+	// 2.6 Sentinelle dual-row (playerDB-only, mode canonical).
+	e.runDualRowSentinelBestEffort(ctx, playerDB)
+}
+
+// runLUSRV1UnderRead calcule LUSR v1 (TrueSkill 2 closed-form) sous un segment de
+// LECTURE shared (v1 lit shared + medal map, écrit la PLAYER DB). Skippé en mode
+// canonical=LUSR_V2 (v2 écrit alors directement rating_type='LUSR', Stratégie C).
+// Le Read est relâché en sortie (defer) — AUCUN Read ne doit rester en vol quand
+// le shadow v2 demande son burst Write (garde anti-deadlock).
+func (e *SyncEngine) runLUSRV1UnderRead(ctx context.Context, playerDB *sql.DB, shared *SharedAccess, r *domain.PostSyncResult) {
+	if IsLUSRV2Canonical() {
+		slog.DebugContext(ctx, "post-sync: LUSR v1 skippé (canonical=LUSR_V2)", "gamertag", e.gamertag)
+		return
+	}
+	sharedDB, releaseRead, rerr := shared.Read(ctx)
+	if rerr != nil {
+		slog.WarnContext(ctx, "post-sync: LUSR v1 — lecture shared indisponible, skippé",
+			"gamertag", e.gamertag, "err", rerr)
+		trackFatalErr(r, "lusr shared read", rerr)
+		return
+	}
+	defer releaseRead()
+	slog.DebugContext(ctx, "post-sync: calcul LUSR v1", "gamertag", e.gamertag)
+	medalMap := e.loadMedalExploitMapBestEffort(ctx, sharedDB)
+	if n, err := batchComputeLUSR(ctx, playerDB, sharedDB, e.xuid, medalMap, false); err != nil {
+		slog.WarnContext(ctx, "post-sync: LUSR v1 échoué", "gamertag", e.gamertag, "err", err)
+		trackFatalErr(r, "LUSR", err)
+	} else {
+		r.LUSRUpdated = n
+		slog.DebugContext(ctx, "post-sync: LUSR v1 mis à jour", "gamertag", e.gamertag, "count", n)
+	}
+}
+
+// runDualRowSentinelBestEffort exécute la sentinelle dual-row (Sprint 2.C) —
+// SEULEMENT en mode canonical (sinon la table LUSR_V2 n'est pas censée exister).
+// Détecte l'invariant Stratégie C cassé (match avec LUSR_V2 sans LUSR). Read-only
+// sur la PLAYER DB (n'a pas besoin de shared), idempotente, timeout 30s pour ne
+// jamais bloquer le post-sync. Toute incohérence → slog.ErrorContext.
+func (e *SyncEngine) runDualRowSentinelBestEffort(ctx context.Context, playerDB *sql.DB) {
+	if !IsLUSRV2Canonical() || playerDB == nil {
+		return
+	}
+	sentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	report, serr := RunDualRowSentinel(sentCtx, playerDB)
+	cancel()
+	switch {
+	case serr != nil:
+		slog.ErrorContext(ctx, "post-sync: sentinelle dual-row échouée",
+			"err", serr, "gamertag", e.gamertag)
+	case report.OnlyLUSRV2 > 0:
+		slog.ErrorContext(ctx, "post-sync: sentinelle dual-row a détecté des incohérences",
+			"gamertag", e.gamertag,
+			"only_lusr_v2", report.OnlyLUSRV2,
+			"sample", report.SampleInconsistent,
+		)
 	}
 }
 

--- a/apps/go-api/internal/sync/lusr_full_recompute.go
+++ b/apps/go-api/internal/sync/lusr_full_recompute.go
@@ -43,7 +43,9 @@ func RecomputeLUSRCanonicalForPlayer(ctx context.Context, playerDB, sharedDB *sq
 		FROM player_skill_state_v2_latest WHERE xuid = ?`, xuid); err != nil {
 		return 0, fmt.Errorf("RecomputeLUSRCanonicalForPlayer reset watermark: %w", err)
 	}
-	n, err := RunLUSRV2ShadowOwnerOnly(ctx, playerDB, sharedDB, xuid)
+	// sharedDB est un handle DÉJÀ TENU par le caller (writer primaire) → mode pinned
+	// (Read/Write retournent ce handle). Le shadow persiste via son burst Write.
+	n, err := RunLUSRV2ShadowOwnerOnly(ctx, playerDB, NewPinnedSharedAccess(sharedDB), xuid)
 	if err != nil {
 		return n, fmt.Errorf("RecomputeLUSRCanonicalForPlayer replay: %w", err)
 	}

--- a/apps/go-api/internal/sync/skill/skill_v2_capability_test.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_capability_test.go
@@ -59,7 +59,7 @@ func TestRunLUSRV2Shadow_SkipsIfNoLUSRCapability(t *testing.T) {
 	ctx := ctxkeys.WithTitleSlug(context.Background(), "some_future_title")
 
 	var nilShared *sql.DB
-	n, err := RunLUSRV2Shadow(ctx, nil, nilShared, "xuid-123")
+	n, err := RunLUSRV2Shadow(ctx, nil, newPinnedSharedAccessor(nilShared), "xuid-123")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow sans capability: err = %v, want nil (gate avant check sharedDB)", err)
 	}

--- a/apps/go-api/internal/sync/skill/skill_v2_shadow.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_shadow.go
@@ -147,14 +147,21 @@ func runLUSRV2Shadow(ctx context.Context, playerDB *sql.DB, shared SharedAccesso
 		priorsCache:      make(map[string]skillv2.Priors),
 		countHypCache:    make(map[string]map[skillv2.CountType]skillv2.CountHyperparams),
 	}
+	ctxRun.squadEnabled = IsLUSRV2SquadOffsetEnabled()
 	var s shadowRunStats
 	// heldGroups : groupes dont un match a échoué son écriture canonical ce run.
 	// Les matchs plus RÉCENTS de ces groupes sont sautés pour ne pas avancer le
 	// watermark de groupe par-dessus un match non écrit (anti-gap, fix 2026-06-07).
 	// Partagé entre chunks (l'ordre chrono ASC est préservé par le découpage).
 	heldGroups := make(map[string]bool)
-	withGameplayDur := 0 // matchs ayant une durée gameplay → pondération temps-joué alimentée
-	squadEnabled := IsLUSRV2SquadOffsetEnabled()
+	// Observabilité TS2 : nb de matchs ayant une durée gameplay connue (wᵢ alimenté).
+	// Comptabilisé une fois sur l'ensemble (indépendant du découpage en chunks).
+	withGameplayDur := 0
+	for _, m := range matches {
+		if m.gameplayDurMs > 0 {
+			withGameplayDur++
+		}
+	}
 
 	// Persistance per-match sous bursts Write("lusr") COURTS et chunkés : la
 	// fenêtre RW est bornée par postsyncLUSRBurstChunk, les lecteurs passent entre
@@ -175,7 +182,7 @@ func runLUSRV2Shadow(ctx context.Context, playerDB *sql.DB, shared SharedAccesso
 			slog.WarnContext(ctx, "LUSR v2 shadow: burst write handle nil — reste reporté", "xuid", xuid)
 			break
 		}
-		processShadowChunk(ctx, ctxRun, burstDB, squadEnabled, matches[start:end], &s, heldGroups, &withGameplayDur)
+		processShadowChunk(ctx, ctxRun, burstDB, matches[start:end], &s, heldGroups)
 		release()
 	}
 	slog.InfoContext(ctx, "LUSR v2 shadow terminé",
@@ -213,8 +220,11 @@ type shadowRunContext struct {
 	// ownerOnlyPersist : recovery backfill — ne persiste que l'état du joueur
 	// traité (pas les coéquipiers). Voir RunLUSRV2ShadowOwnerOnly.
 	ownerOnlyPersist bool
-	priorsCache      map[string]skillv2.Priors
-	countHypCache    map[string]map[skillv2.CountType]skillv2.CountHyperparams
+	// squadEnabled : LEVELUP_LUSR_V2_SQUAD_OFFSET actif → squadRepo câblé par chunk.
+	// Porté ici (pas en paramètre) pour borner le nb d'arguments de processShadowChunk.
+	squadEnabled  bool
+	priorsCache   map[string]skillv2.Priors
+	countHypCache map[string]map[skillv2.CountType]skillv2.CountHyperparams
 }
 
 // shadowRunStats compte les buckets de skip pour le log de fin de run.

--- a/apps/go-api/internal/sync/skill/skill_v2_shadow.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_shadow.go
@@ -22,7 +22,6 @@ import (
 	skillv2 "levelup/go-api/internal/analysis/skill_v2"
 	"levelup/go-api/internal/ctxkeys"
 	"levelup/go-api/internal/domain"
-	"levelup/go-api/internal/platform/duckdb"
 	"levelup/go-api/internal/port"
 )
 
@@ -80,8 +79,8 @@ type shadowParticipant struct {
 // Variante "persist des 2 équipes" (avance le watermark de TOUS les participants).
 // N'est PLUS utilisée par le live (cf. RunLUSRV2ShadowOwnerOnly, fix 2026-06-08,
 // couplage cross-joueur) — conservée pour cmd/lusr_v2_replay et les tests.
-func RunLUSRV2Shadow(ctx context.Context, playerDB, sharedDB *sql.DB, xuid string) (int, error) {
-	return runLUSRV2Shadow(ctx, playerDB, sharedDB, xuid, false)
+func RunLUSRV2Shadow(ctx context.Context, playerDB *sql.DB, shared SharedAccessor, xuid string) (int, error) {
+	return runLUSRV2Shadow(ctx, playerDB, shared, xuid, false)
 }
 
 // RunLUSRV2ShadowOwnerOnly : persiste UNIQUEMENT l'état v2 du joueur traité (pas
@@ -99,11 +98,11 @@ func RunLUSRV2Shadow(ctx context.Context, playerDB, sharedDB *sql.DB, xuid strin
 // Compromis assumé : l'EP du joueur lit l'état COURANT de ses coéquipiers (pas
 // forcément leur état pré-match) — approximation inhérente au modèle per-joueur,
 // identique entre live et backfill (résultats cohérents).
-func RunLUSRV2ShadowOwnerOnly(ctx context.Context, playerDB, sharedDB *sql.DB, xuid string) (int, error) {
-	return runLUSRV2Shadow(ctx, playerDB, sharedDB, xuid, true)
+func RunLUSRV2ShadowOwnerOnly(ctx context.Context, playerDB *sql.DB, shared SharedAccessor, xuid string) (int, error) {
+	return runLUSRV2Shadow(ctx, playerDB, shared, xuid, true)
 }
 
-func runLUSRV2Shadow(ctx context.Context, playerDB, sharedDB *sql.DB, xuid string, ownerOnlyPersist bool) (int, error) {
+func runLUSRV2Shadow(ctx context.Context, playerDB *sql.DB, shared SharedAccessor, xuid string, ownerOnlyPersist bool) (int, error) {
 	if !IsLUSRV2Enabled() {
 		return 0, nil
 	}
@@ -112,8 +111,8 @@ func runLUSRV2Shadow(ctx context.Context, playerDB, sharedDB *sql.DB, xuid strin
 	if skipIfNoLUSRCapability(ctx, "RunLUSRV2Shadow") {
 		return 0, nil
 	}
-	if sharedDB == nil {
-		return 0, fmt.Errorf("RunLUSRV2Shadow: sharedDB nil")
+	if shared == nil {
+		return 0, fmt.Errorf("RunLUSRV2Shadow: shared nil")
 	}
 	canonical := IsLUSRV2Canonical()
 	if canonical && playerDB == nil {
@@ -124,36 +123,24 @@ func runLUSRV2Shadow(ctx context.Context, playerDB, sharedDB *sql.DB, xuid strin
 		canonical = false
 	}
 
-	// Découplage (Axe 2 refactor) : la logique en aval dépend des interfaces
-	// port.* ; seul ce point d'instanciation connaît le type concret DuckDB.
-	var repo port.SkillV2Repository = duckdb.NewSkillV2Repo(sharedDB)
-	// Sprint 1.C : repo squad seulement si le flag est actif (OFF par défaut →
-	// interface nil → aucun offset appliqué, comportement strictement inchangé).
-	// Déclaré en type interface : assigner un *duckdb.SquadOffsetRepo nil à une
-	// interface donnerait un typed-nil (interface NON nil) qui casserait le
-	// garde `repo == nil` de computeTeamSquadOffsets.
-	var squadRepo port.SquadOffsetRepository
-	if IsLUSRV2SquadOffsetEnabled() {
-		squadRepo = duckdb.NewSquadOffsetRepo(sharedDB)
-	}
-	priors := skillv2.DefaultPriors()
-	tierBoundaries := skillv2.DefaultTierBoundaries() // Phase 5 batch écrira override
-
-	matches, err := loadShadowMatches(ctx, sharedDB, xuid)
+	// Sélection sous segment LECTURE, release IMMÉDIAT (pur SELECT). Le Read est
+	// relâché AVANT tout burst Write (garde anti-deadlock). Régression 2026-07-03 :
+	// le persist per-match ne doit JAMAIS passer par ce handle de lecture (RO en
+	// mode burst) — il passe par des bursts Write (RW) ci-dessous.
+	matches, err := loadShadowMatchesUnderRead(ctx, shared, xuid)
 	if err != nil {
 		return 0, fmt.Errorf("RunLUSRV2Shadow.loadShadowMatches: %w", err)
 	}
 	if len(matches) == 0 {
-		return 0, nil
+		return 0, nil // cas stationnaire dominant : AUCUN burst Write acquis
 	}
 
 	ctxRun := shadowRunContext{
-		repo:             repo,
-		squadRepo:        squadRepo,
+		// repo / squadRepo / sharedDB sont câblés PAR CHUNK sur le handle du burst
+		// Write courant (cf. processShadowChunk) — jamais sur le handle de lecture.
 		playerDB:         playerDB,
-		sharedDB:         sharedDB,
-		priors:           priors,
-		tierBoundaries:   tierBoundaries,
+		priors:           skillv2.DefaultPriors(),
+		tierBoundaries:   skillv2.DefaultTierBoundaries(), // Phase 5 batch écrira override
 		xuid:             xuid,
 		canonical:        canonical,
 		ownerOnlyPersist: ownerOnlyPersist,
@@ -164,13 +151,32 @@ func runLUSRV2Shadow(ctx context.Context, playerDB, sharedDB *sql.DB, xuid strin
 	// heldGroups : groupes dont un match a échoué son écriture canonical ce run.
 	// Les matchs plus RÉCENTS de ces groupes sont sautés pour ne pas avancer le
 	// watermark de groupe par-dessus un match non écrit (anti-gap, fix 2026-06-07).
+	// Partagé entre chunks (l'ordre chrono ASC est préservé par le découpage).
 	heldGroups := make(map[string]bool)
 	withGameplayDur := 0 // matchs ayant une durée gameplay → pondération temps-joué alimentée
-	for _, m := range matches {
-		if m.gameplayDurMs > 0 {
-			withGameplayDur++
+	squadEnabled := IsLUSRV2SquadOffsetEnabled()
+
+	// Persistance per-match sous bursts Write("lusr") COURTS et chunkés : la
+	// fenêtre RW est bornée par postsyncLUSRBurstChunk, les lecteurs passent entre
+	// les chunks. La dépendance séquentielle des états EP impose de persister au fil
+	// de l'eau — le chunk borne la fenêtre RW sans casser l'ordre.
+	for start := 0; start < len(matches); start += postsyncLUSRBurstChunk {
+		end := min(start+postsyncLUSRBurstChunk, len(matches))
+		burstDB, release, werr := shared.Write(ctx, "lusr")
+		if werr != nil {
+			// Shared indisponible / read-only (probe burst) → dégradation propre :
+			// on reporte le reste au prochain cycle (watermark non avancé, retry).
+			slog.WarnContext(ctx, "LUSR v2 shadow: burst write shared indisponible — reste reporté au prochain cycle",
+				"xuid", xuid, "remaining", len(matches)-start, "err", werr)
+			break
 		}
-		processOneShadowMatch(ctx, ctxRun, m, &s, heldGroups)
+		if burstDB == nil {
+			release()
+			slog.WarnContext(ctx, "LUSR v2 shadow: burst write handle nil — reste reporté", "xuid", xuid)
+			break
+		}
+		processShadowChunk(ctx, ctxRun, burstDB, squadEnabled, matches[start:end], &s, heldGroups, &withGameplayDur)
+		release()
 	}
 	slog.InfoContext(ctx, "LUSR v2 shadow terminé",
 		"xuid", xuid, "processed", s.processed,

--- a/apps/go-api/internal/sync/skill/skill_v2_shadow_burst_test.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_shadow_burst_test.go
@@ -1,0 +1,226 @@
+//go:build cgo
+
+package skill
+
+// skill_v2_shadow_burst_test.go — verrouille le fix hotfix/lusr-shadow-ro
+// (régression prod 2026-07-03) : le shadow LUSR v2 persiste via des bursts Write
+// (RW), jamais sur le handle de LECTURE (RO en mode burst). Deux propriétés :
+//   1. Read-only guard : Read sert un attach READ_ONLY (la sélection y passe),
+//      Write sert un attach RW (le persist y passe) → le run traite ET persiste,
+//      le watermark avance. Sur l'ancien code (persist via le handle unique de
+//      lecture) l'INSERT échouait « attached in read-only mode » → processed=0.
+//   2. Anti-deadlock : aucun burst Write n'est demandé pendant qu'un Read du même
+//      accès est en vol (le garde de SharedAccess.Write transformerait le bug en
+//      erreur) — vérifié y compris sur > 1 chunk.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// seedShadow2v2 insère un match 2v2 LUSR-éligible (owner+teammate1 vs opp1+opp2,
+// pair_name "Slayer" → arena_slayer, owner gagnant) dans le handle fourni.
+func seedShadow2v2(t *testing.T, db *sql.DB, matchID string, start time.Time) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO match_registry
+		(match_id, start_time, start_time_utc, pair_name, is_ranked, is_firefight, duration_seconds)
+		VALUES (?, ?, ?, 'Slayer', FALSE, FALSE, 600)`, matchID, start, start); err != nil {
+		t.Fatalf("seed match_registry(%s): %v", matchID, err)
+	}
+	for _, q := range []struct {
+		x      string
+		tm, oc int
+		k, d   int
+	}{{"owner", 0, 2, 18, 6}, {"teammate1", 0, 2, 12, 9}, {"opp1", 1, 3, 7, 14}, {"opp2", 1, 3, 8, 14}} {
+		if _, err := db.Exec(`INSERT INTO match_participants
+			(match_id, xuid, team_id, outcome, kills, deaths) VALUES (?, ?, ?, ?, ?, ?)`,
+			matchID, q.x, q.tm, q.oc, q.k, q.d); err != nil {
+			t.Fatalf("seed participant(%s,%s): %v", matchID, q.x, err)
+		}
+	}
+}
+
+// openShadowTestFileDB crée une DB DuckDB FICHIER seedée avec le schéma shadow,
+// et retourne son chemin (slash-normalisé pour ATTACH). La connexion RW de seed
+// est FERMÉE avant retour → les attach RO/RW ultérieurs ne se disputent pas le lock.
+func openShadowTestFileDB(t *testing.T) string {
+	t.Helper()
+	path := filepath.ToSlash(filepath.Join(t.TempDir(), "shared.duckdb"))
+	rw, err := sql.Open("duckdb", path)
+	if err != nil {
+		t.Fatalf("open file db: %v", err)
+	}
+	if _, err := rw.Exec(shadowSchemaDDL); err != nil {
+		_ = rw.Close()
+		t.Fatalf("file DDL: %v", err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatalf("close seed conn: %v", err)
+	}
+	return path
+}
+
+// roRwSplitAccess : SharedAccessor où Read ouvre un attach READ_ONLY du fichier
+// (SELECT OK, INSERT interdit) et Write un attach RW. Reproduit la topologie prod
+// B-swap : Read et Write ne sont JAMAIS ouverts simultanément (le shadow release
+// le Read avant tout burst), donc pas de conflit de lock fichier.
+type roRwSplitAccess struct {
+	path       string
+	readCalls  int
+	writeCalls int
+}
+
+func (a *roRwSplitAccess) attach(ctx context.Context, readOnly bool) (*sql.DB, error) {
+	c, err := sql.Open("duckdb", "")
+	if err != nil {
+		return nil, err
+	}
+	mode := ""
+	if readOnly {
+		mode = " (READ_ONLY)"
+	}
+	if _, err := c.ExecContext(ctx, "ATTACH '"+a.path+"' AS s"+mode); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	if _, err := c.ExecContext(ctx, "USE s"); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (a *roRwSplitAccess) Read(ctx context.Context) (*sql.DB, func(), error) {
+	a.readCalls++
+	c, err := a.attach(ctx, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, func() { _ = c.Close() }, nil
+}
+
+func (a *roRwSplitAccess) Write(ctx context.Context, _ string) (*sql.DB, func(), error) {
+	a.writeCalls++
+	c, err := a.attach(ctx, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, func() { _ = c.Close() }, nil
+}
+
+// TestLUSRV2Shadow_PersistsViaWriteBurst_WhenReadHandleIsReadOnly : la sélection
+// passe par un handle read-only, le persist par un burst RW → traite ET persiste,
+// le watermark avance. Sur l'ancien code (handle unique de lecture) : ROUGE.
+func TestLUSRV2Shadow_PersistsViaWriteBurst_WhenReadHandleIsReadOnly(t *testing.T) {
+	t.Setenv(lusrV2EnvFlag, "1")
+	t.Setenv(lusrCanonicalEnvFlag, "") // shadow-only (v1 canonical par défaut)
+
+	path := openShadowTestFileDB(t)
+	// seed via une connexion RW éphémère (refermée avant les attach).
+	seed, err := sql.Open("duckdb", path)
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	seedShadow2v2(t, seed, "m1", time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC))
+	if err := seed.Close(); err != nil {
+		t.Fatalf("close seed: %v", err)
+	}
+
+	acc := &roRwSplitAccess{path: path}
+	processed, err := RunLUSRV2ShadowOwnerOnly(context.Background(), nil, acc, "owner")
+	if err != nil {
+		t.Fatalf("RunLUSRV2ShadowOwnerOnly: %v", err)
+	}
+	if processed != 1 {
+		t.Fatalf("processed = %d, want 1 (persist doit passer par le burst Write RW)", processed)
+	}
+	if acc.writeCalls < 1 {
+		t.Errorf("writeCalls = %d, want >= 1 (le persist doit acquérir un burst Write)", acc.writeCalls)
+	}
+
+	// Vérifie l'avance du watermark : l'état owner existe et porte last_match_at.
+	verify, err := sql.Open("duckdb", path)
+	if err != nil {
+		t.Fatalf("open verify: %v", err)
+	}
+	defer verify.Close() //nolint:errcheck
+	var exp int
+	var lastAt sql.NullTime
+	err = verify.QueryRow(`SELECT experience, last_match_at FROM player_skill_state_v2_latest
+		WHERE xuid = 'owner' AND playlist_group = 'arena_slayer'`).Scan(&exp, &lastAt)
+	if err != nil {
+		t.Fatalf("state owner introuvable après run (persist non effectué ?): %v", err)
+	}
+	if exp != 1 {
+		t.Errorf("experience = %d, want 1", exp)
+	}
+	if !lastAt.Valid {
+		t.Error("last_match_at NULL — le watermark n'a pas avancé")
+	}
+}
+
+// orderTrackingAccess : SharedAccessor sur un handle unique in-memory qui ÉCHOUE
+// le test si un Write est demandé pendant qu'un Read est en vol (garde
+// anti-deadlock). Compte aussi les bursts Write.
+type orderTrackingAccess struct {
+	db              *sql.DB
+	mu              sync.Mutex
+	readOutstanding int
+	writeCalls      int
+	violation       string
+}
+
+func (a *orderTrackingAccess) Read(context.Context) (*sql.DB, func(), error) {
+	a.mu.Lock()
+	a.readOutstanding++
+	a.mu.Unlock()
+	return a.db, func() {
+		a.mu.Lock()
+		a.readOutstanding--
+		a.mu.Unlock()
+	}, nil
+}
+
+func (a *orderTrackingAccess) Write(_ context.Context, step string) (*sql.DB, func(), error) {
+	a.mu.Lock()
+	a.writeCalls++
+	if a.readOutstanding > 0 && a.violation == "" {
+		a.violation = fmt.Sprintf("Write(%s) demandé avec %d Read en vol", step, a.readOutstanding)
+	}
+	a.mu.Unlock()
+	return a.db, func() {}, nil
+}
+
+// TestLUSRV2Shadow_ReleasesReadBeforeWriteBurst_MultiChunk : sur 4 matchs (> 1
+// chunk de 3), le shadow traite tout, acquiert plusieurs bursts Write, et ne
+// demande JAMAIS un Write pendant qu'un Read est en vol.
+func TestLUSRV2Shadow_ReleasesReadBeforeWriteBurst_MultiChunk(t *testing.T) {
+	t.Setenv(lusrV2EnvFlag, "1")
+	t.Setenv(lusrCanonicalEnvFlag, "")
+
+	db := openShadowTestDB(t)
+	base := time.Date(2025, 2, 1, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		seedShadow2v2(t, db, fmt.Sprintf("mc%d", i), base.Add(time.Duration(i)*time.Hour))
+	}
+
+	acc := &orderTrackingAccess{db: db}
+	processed, err := RunLUSRV2ShadowOwnerOnly(context.Background(), nil, acc, "owner")
+	if err != nil {
+		t.Fatalf("RunLUSRV2ShadowOwnerOnly: %v", err)
+	}
+	if processed != 4 {
+		t.Errorf("processed = %d, want 4 (tous les matchs des 2 chunks)", processed)
+	}
+	if acc.violation != "" {
+		t.Errorf("garde anti-deadlock violée : %s", acc.violation)
+	}
+	if acc.writeCalls < 2 {
+		t.Errorf("writeCalls = %d, want >= 2 (4 matchs → chunks de 3 → 2 bursts)", acc.writeCalls)
+	}
+}

--- a/apps/go-api/internal/sync/skill/skill_v2_shadow_test.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_shadow_test.go
@@ -490,7 +490,7 @@ func TestRunLUSRV2Shadow_FlagOff_NoOp(t *testing.T) {
 	_ = os.Setenv(lusrV2EnvFlag, "0")
 
 	db := openShadowTestDB(t)
-	n, err := RunLUSRV2Shadow(context.Background(), nil, db, "anyxuid")
+	n, err := RunLUSRV2Shadow(context.Background(), nil, newPinnedSharedAccessor(db), "anyxuid")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
@@ -531,7 +531,7 @@ func TestRunLUSRV2Shadow_FullFlow_2v2Match(t *testing.T) {
 		}
 	}
 
-	processed, err := RunLUSRV2Shadow(context.Background(), nil, db, "owner")
+	processed, err := RunLUSRV2Shadow(context.Background(), nil, newPinnedSharedAccessor(db), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
@@ -567,7 +567,7 @@ func TestRunLUSRV2Shadow_FullFlow_2v2Match(t *testing.T) {
 	}
 
 	// Re-run : watermark → 0 traités.
-	processed2, err := RunLUSRV2Shadow(context.Background(), nil, db, "owner")
+	processed2, err := RunLUSRV2Shadow(context.Background(), nil, newPinnedSharedAccessor(db), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow second pass: %v", err)
 	}
@@ -613,7 +613,7 @@ func TestRunLUSRV2ShadowOwnerOnly_TeammateDoesNotBlockOwner(t *testing.T) {
 	ctx := context.Background()
 
 	// 1) Coéquipier traité en premier (owner-only).
-	n1, err := RunLUSRV2ShadowOwnerOnly(ctx, nil, db, "teammate1")
+	n1, err := RunLUSRV2ShadowOwnerOnly(ctx, nil, newPinnedSharedAccessor(db), "teammate1")
 	if err != nil {
 		t.Fatalf("owner-only teammate1: %v", err)
 	}
@@ -627,7 +627,7 @@ func TestRunLUSRV2ShadowOwnerOnly_TeammateDoesNotBlockOwner(t *testing.T) {
 	}
 
 	// 2) Owner traité ensuite : NE doit PAS être bloqué (autonomie).
-	n2, err := RunLUSRV2ShadowOwnerOnly(ctx, nil, db, "owner")
+	n2, err := RunLUSRV2ShadowOwnerOnly(ctx, nil, newPinnedSharedAccessor(db), "owner")
 	if err != nil {
 		t.Fatalf("owner-only owner: %v", err)
 	}
@@ -681,7 +681,7 @@ func TestRunLUSRV2Shadow_Canonical_WritesLegacyLUSRRow(t *testing.T) {
 		}
 	}
 
-	processed, err := RunLUSRV2Shadow(context.Background(), playerDB, sharedDB, "owner")
+	processed, err := RunLUSRV2Shadow(context.Background(), playerDB, newPinnedSharedAccessor(sharedDB), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
@@ -838,7 +838,7 @@ func TestRunLUSRV2Shadow_RankedSkipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("insert: %v", err)
 	}
-	processed, err := RunLUSRV2Shadow(context.Background(), nil, db, "owner")
+	processed, err := RunLUSRV2Shadow(context.Background(), nil, newPinnedSharedAccessor(db), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
@@ -900,7 +900,7 @@ func TestRunLUSRV2Shadow_Phase4_CrossModeLeak(t *testing.T) {
 		}
 	}
 
-	if _, err := RunLUSRV2Shadow(ctx, nil, db, "owner"); err != nil {
+	if _, err := RunLUSRV2Shadow(ctx, nil, newPinnedSharedAccessor(db), "owner"); err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
 
@@ -979,7 +979,7 @@ func TestRunLUSRV2Shadow_Phase4_ExplicitlyOff(t *testing.T) {
 			t.Fatalf("insert participant: %v", err)
 		}
 	}
-	if _, err := RunLUSRV2Shadow(ctx, nil, db, "owner"); err != nil {
+	if _, err := RunLUSRV2Shadow(ctx, nil, newPinnedSharedAccessor(db), "owner"); err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
 
@@ -1049,7 +1049,7 @@ func TestRunLUSRV2Shadow_Halo5_TitleAwareChain(t *testing.T) {
 	seedH5Match(t, sharedDB, "h5_m1", time.Date(2025, 11, 1, 14, 0, 0, 0, time.UTC))
 
 	ctx := ctxkeys.WithTitleSlug(context.Background(), "halo_5")
-	processed, err := RunLUSRV2ShadowOwnerOnly(ctx, nil, sharedDB, "owner")
+	processed, err := RunLUSRV2ShadowOwnerOnly(ctx, nil, newPinnedSharedAccessor(sharedDB), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2ShadowOwnerOnly: %v", err)
 	}
@@ -1111,7 +1111,7 @@ func TestRunLUSRV2Shadow_Canonical_StoresExpectedWinProb(t *testing.T) {
 	playerDB := openCanonicalPlayerTestDB(t)
 	seedCanonical2v2(t, sharedDB, "m_winprob", time.Date(2025, 3, 1, 14, 0, 0, 0, time.UTC))
 
-	if _, err := RunLUSRV2Shadow(context.Background(), playerDB, sharedDB, "owner"); err != nil {
+	if _, err := RunLUSRV2Shadow(context.Background(), playerDB, newPinnedSharedAccessor(sharedDB), "owner"); err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
 
@@ -1145,7 +1145,7 @@ func TestRunLUSRV2Shadow_Canonical_FirstMatchFallback(t *testing.T) {
 	playerDB := openCanonicalPlayerTestDB(t)
 	seedCanonical2v2(t, sharedDB, "m_firstmatch", time.Date(2025, 3, 2, 14, 0, 0, 0, time.UTC))
 
-	if _, err := RunLUSRV2Shadow(context.Background(), playerDB, sharedDB, "owner"); err != nil {
+	if _, err := RunLUSRV2Shadow(context.Background(), playerDB, newPinnedSharedAccessor(sharedDB), "owner"); err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
 
@@ -1200,7 +1200,7 @@ func TestRunLUSRV2Shadow_UsesEmpiricalDrawProb(t *testing.T) {
 				t.Fatalf("insert participant: %v", err)
 			}
 		}
-		if _, err := RunLUSRV2Shadow(context.Background(), nil, db, "owner"); err != nil {
+		if _, err := RunLUSRV2Shadow(context.Background(), nil, newPinnedSharedAccessor(db), "owner"); err != nil {
 			t.Fatalf("RunLUSRV2Shadow: %v", err)
 		}
 		st, err := duckdb.NewSkillV2Repo(db).LoadState(context.Background(), "owner", "arena_slayer")
@@ -1264,7 +1264,7 @@ func TestRunLUSRV2Shadow_AppliesSquadOffset(t *testing.T) {
 				t.Fatalf("insert participant: %v", err)
 			}
 		}
-		if _, err := RunLUSRV2Shadow(context.Background(), nil, db, "owner"); err != nil {
+		if _, err := RunLUSRV2Shadow(context.Background(), nil, newPinnedSharedAccessor(db), "owner"); err != nil {
 			t.Fatalf("RunLUSRV2Shadow: %v", err)
 		}
 		st, err := duckdb.NewSkillV2Repo(db).LoadState(context.Background(), "owner", "arena_slayer")
@@ -1307,7 +1307,7 @@ func TestRunLUSRV2Shadow_Canonical_RatingDelta(t *testing.T) {
 	seedCanonical2v2(t, sharedDB, "m1", time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC))
 	seedCanonical2v2(t, sharedDB, "m2", time.Date(2025, 6, 1, 13, 0, 0, 0, time.UTC))
 
-	if _, err := RunLUSRV2Shadow(context.Background(), playerDB, sharedDB, "owner"); err != nil {
+	if _, err := RunLUSRV2Shadow(context.Background(), playerDB, newPinnedSharedAccessor(sharedDB), "owner"); err != nil {
 		t.Fatalf("RunLUSRV2Shadow: %v", err)
 	}
 
@@ -1375,7 +1375,7 @@ func TestRunLUSRV2Shadow_QuitContext_LeadingAtQuit(t *testing.T) {
 				}
 			}
 		}
-		if _, err := RunLUSRV2Shadow(context.Background(), nil, db, "owner"); err != nil {
+		if _, err := RunLUSRV2Shadow(context.Background(), nil, newPinnedSharedAccessor(db), "owner"); err != nil {
 			t.Fatalf("RunLUSRV2Shadow: %v", err)
 		}
 		st, err := duckdb.NewSkillV2Repo(db).LoadState(context.Background(), "owner", "arena_slayer")
@@ -1428,7 +1428,7 @@ func TestRunLUSRV2Shadow_Canonical_WriteFailHoldsWatermark(t *testing.T) {
 	}
 	_ = brokenPlayerDB.Close() // fermeture volontaire = reproduit l'incident 03/06
 
-	processed, err := RunLUSRV2Shadow(ctx, brokenPlayerDB, sharedDB, "owner")
+	processed, err := RunLUSRV2Shadow(ctx, brokenPlayerDB, newPinnedSharedAccessor(sharedDB), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow (broken): %v", err)
 	}
@@ -1442,7 +1442,7 @@ func TestRunLUSRV2Shadow_Canonical_WriteFailHoldsWatermark(t *testing.T) {
 
 	// 2) Retry avec une player DB saine → le match tenu passe ET écrit la ligne LUSR.
 	goodPlayerDB := openCanonicalPlayerTestDB(t)
-	processed2, err := RunLUSRV2Shadow(ctx, goodPlayerDB, sharedDB, "owner")
+	processed2, err := RunLUSRV2Shadow(ctx, goodPlayerDB, newPinnedSharedAccessor(sharedDB), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow (retry): %v", err)
 	}
@@ -1494,7 +1494,7 @@ func TestRunLUSRV2Shadow_Canonical_HeldGroupSkipsLaterMatches(t *testing.T) {
 	}
 	_ = brokenPlayerDB.Close()
 
-	processed, err := RunLUSRV2Shadow(ctx, brokenPlayerDB, sharedDB, "owner")
+	processed, err := RunLUSRV2Shadow(ctx, brokenPlayerDB, newPinnedSharedAccessor(sharedDB), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow (broken): %v", err)
 	}
@@ -1515,7 +1515,7 @@ func TestRunLUSRV2Shadow_Canonical_HeldGroupSkipsLaterMatches(t *testing.T) {
 
 	// 2) Retry avec player DB saine → les DEUX matchs sont traités, EN ORDRE, aucun gap.
 	goodPlayerDB := openCanonicalPlayerTestDB(t)
-	processed2, err := RunLUSRV2Shadow(ctx, goodPlayerDB, sharedDB, "owner")
+	processed2, err := RunLUSRV2Shadow(ctx, goodPlayerDB, newPinnedSharedAccessor(sharedDB), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2Shadow (retry): %v", err)
 	}
@@ -1629,7 +1629,7 @@ func TestRunLUSRV2ShadowOwnerOnly_DoesNotOverwriteTeammateState(t *testing.T) {
 	// Match owner+teammate vs opp1+opp2 (pair_name 'Slayer' → arena_slayer).
 	seedCanonical2v2(t, sharedDB, "m_oo", time.Date(2025, 9, 2, 12, 0, 0, 0, time.UTC))
 
-	processed, err := RunLUSRV2ShadowOwnerOnly(ctx, playerDB, sharedDB, "owner")
+	processed, err := RunLUSRV2ShadowOwnerOnly(ctx, playerDB, newPinnedSharedAccessor(sharedDB), "owner")
 	if err != nil {
 		t.Fatalf("RunLUSRV2ShadowOwnerOnly: %v", err)
 	}

--- a/apps/go-api/internal/sync/skill/skill_v2_shadow_test.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_shadow_test.go
@@ -326,7 +326,15 @@ func openShadowTestDB(t *testing.T) *sql.DB {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	const ddl = `
+	if _, err := db.Exec(shadowSchemaDDL); err != nil {
+		t.Fatalf("DDL: %v", err)
+	}
+	return db
+}
+
+// shadowSchemaDDL : schéma minimal partagé par les DB de test du shadow (in-memory
+// via openShadowTestDB, fichier via openShadowTestFileDB pour le test read-only).
+const shadowSchemaDDL = `
 		CREATE TABLE match_registry (
 			match_id VARCHAR PRIMARY KEY,
 			start_time TIMESTAMP,
@@ -418,11 +426,6 @@ func openShadowTestDB(t *testing.T) *sql.DB {
 		) m ON o.xuid = m.xuid AND o.partner_xuid = m.partner_xuid
 		     AND o.playlist_group = m.playlist_group AND o.written_at = m.max_written_at;
 	`
-	if _, err := db.Exec(ddl); err != nil {
-		t.Fatalf("DDL: %v", err)
-	}
-	return db
-}
 
 func TestBuildTwoTeamRosters_TwoTeamsOK(t *testing.T) {
 	db := openShadowTestDB(t)

--- a/apps/go-api/internal/sync/skill/skill_v2_shared_access.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_shared_access.go
@@ -76,21 +76,18 @@ func loadShadowMatchesUnderRead(ctx context.Context, shared SharedAccessor, xuid
 // persistance UpsertState va donc sur un handle inscriptible (fix read-only
 // 2026-07-03). `base` est copié par valeur mais ses caches (maps) et heldGroups
 // sont des références partagées → l'état de run survit d'un chunk au suivant.
-func processShadowChunk(ctx context.Context, base shadowRunContext, burstDB *sql.DB, squadEnabled bool,
-	chunk []shadowMatch, s *shadowRunStats, heldGroups map[string]bool, withGameplayDur *int) {
+func processShadowChunk(ctx context.Context, base shadowRunContext, burstDB *sql.DB,
+	chunk []shadowMatch, s *shadowRunStats, heldGroups map[string]bool) {
 	c := base
 	c.sharedDB = burstDB
 	c.repo = duckdb.NewSkillV2Repo(burstDB)
 	// squadRepo seulement si le flag est actif (sinon interface nil → offsets nuls,
 	// comportement strictement inchangé ; un typed-nil casserait le garde de
 	// computeTeamSquadOffsets).
-	if squadEnabled {
+	if c.squadEnabled {
 		c.squadRepo = duckdb.NewSquadOffsetRepo(burstDB)
 	}
 	for _, m := range chunk {
-		if m.gameplayDurMs > 0 {
-			*withGameplayDur++
-		}
 		processOneShadowMatch(ctx, c, m, s, heldGroups)
 	}
 }

--- a/apps/go-api/internal/sync/skill/skill_v2_shared_access.go
+++ b/apps/go-api/internal/sync/skill/skill_v2_shared_access.go
@@ -1,0 +1,96 @@
+package skill
+
+// skill_v2_shared_access.go — seam d'accès à la DB partagée pour le shadow LUSR
+// v2, et découpage per-match en bursts Write courts.
+//
+// Régression prod 2026-07-03 (fix hotfix/lusr-shadow-ro) : le shadow recevait un
+// *sql.DB unique classé « segment lecture » (en mode burst, un handle RO) et
+// tentait un INSERT dessus → « Cannot execute statement of type INSERT ... which
+// is attached in read-only mode ». Cause : erreur de CLASSIFICATION du refactor
+// contention (le v2 shadow écrit player_skill_state_v2 CÔTÉ SHARED, ce n'est pas
+// un pur lecteur comme le v1). Le seam ci-dessous force la sélection sous Read
+// (RO) et la persistance sous des bursts Write (RW courts).
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"levelup/go-api/internal/platform/duckdb"
+)
+
+// SharedAccessor est le seam d'accès shared du shadow LUSR v2.
+//
+// Le sous-package skill NE PEUT PAS importer internal/sync (cycle sync→skill) :
+// l'interface est déclarée ici et satisfaite STRUCTURELLEMENT par
+// *sync.SharedAccess (mêmes signatures Read/Write). Contrat :
+//   - Read  : handle de LECTURE RO (ne gate personne) — sélection des matchs.
+//   - Write : burst RW COURT labellisé (persistance per-match) ; REFUSE si un
+//     Read du même accès est encore en vol (garde anti-deadlock) → toujours
+//     release le Read AVANT de demander un Write.
+type SharedAccessor interface {
+	Read(ctx context.Context) (*sql.DB, func(), error)
+	Write(ctx context.Context, step string) (*sql.DB, func(), error)
+}
+
+// postsyncLUSRBurstChunk borne la fenêtre RW d'un burst Write("lusr") du shadow :
+// on relâche/ré-acquiert le writer tous les N matchs, les lecteurs passent entre
+// les chunks. Même esprit/valeur que sync.postsyncEventsBurstChunk (=3,
+// internal/sync/engine.go) — dupliqué ici car skill ne peut pas importer sync.
+const postsyncLUSRBurstChunk = 3
+
+// pinnedSharedAccess : SharedAccessor sur un handle DÉJÀ TENU par le caller
+// (CLI/backfill qui possèdent le writer, et tests). Read/Write retournent ce
+// handle, release no-op — parité stricte avec l'ancien passage direct d'un
+// *sql.DB. Équivalent skill-local de sync.NewPinnedSharedAccess (cycle interdit).
+type pinnedSharedAccess struct{ db *sql.DB }
+
+func newPinnedSharedAccessor(db *sql.DB) SharedAccessor { return pinnedSharedAccess{db: db} }
+
+func (p pinnedSharedAccess) Read(context.Context) (*sql.DB, func(), error) {
+	return p.db, func() {}, nil
+}
+
+func (p pinnedSharedAccess) Write(context.Context, string) (*sql.DB, func(), error) {
+	return p.db, func() {}, nil
+}
+
+// loadShadowMatchesUnderRead sélectionne les matchs LUSR-éligibles sous un segment
+// de LECTURE shared (pur SELECT), et RELÂCHE le Read avant de rendre la main — un
+// Read encore en vol ferait échouer le burst Write suivant (garde anti-deadlock).
+func loadShadowMatchesUnderRead(ctx context.Context, shared SharedAccessor, xuid string) ([]shadowMatch, error) {
+	readDB, release, err := shared.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	if readDB == nil {
+		return nil, fmt.Errorf("shared read handle nil")
+	}
+	return loadShadowMatches(ctx, readDB, xuid)
+}
+
+// processShadowChunk traite un chunk de matchs SOUS le handle d'un burst Write
+// (RW). Les repos SkillV2/SquadOffset et TOUTES les lectures per-match (états,
+// rosters, quit timeline) passent par ce handle : un writer lit aussi, et la
+// persistance UpsertState va donc sur un handle inscriptible (fix read-only
+// 2026-07-03). `base` est copié par valeur mais ses caches (maps) et heldGroups
+// sont des références partagées → l'état de run survit d'un chunk au suivant.
+func processShadowChunk(ctx context.Context, base shadowRunContext, burstDB *sql.DB, squadEnabled bool,
+	chunk []shadowMatch, s *shadowRunStats, heldGroups map[string]bool, withGameplayDur *int) {
+	c := base
+	c.sharedDB = burstDB
+	c.repo = duckdb.NewSkillV2Repo(burstDB)
+	// squadRepo seulement si le flag est actif (sinon interface nil → offsets nuls,
+	// comportement strictement inchangé ; un typed-nil casserait le garde de
+	// computeTeamSquadOffsets).
+	if squadEnabled {
+		c.squadRepo = duckdb.NewSquadOffsetRepo(burstDB)
+	}
+	for _, m := range chunk {
+		if m.gameplayDurMs > 0 {
+			*withGameplayDur++
+		}
+		processOneShadowMatch(ctx, c, m, s, heldGroups)
+	}
+}


### PR DESCRIPTION
## Contexte

Régression prod depuis le 2026-07-03 : le LUSR v2 shadow persiste `player_skill_state_v2` (côté shared) sur un handle classé « segment lecture » (RO en mode burst) → `Cannot execute statement of type "INSERT" ... attached in read-only mode` (~6500 WARN/j, watermark LUSR figé, writer RW tenu, `/health` 503 intermittents). Cause : erreur de CLASSIFICATION du refactor contention (le v2 shadow écrit shared, ce n'est pas un pur lecteur comme le v1).

## Fix (conforme burst-lease, pas de revert)

- Interface seam `skill.SharedAccessor` (Read/Write), satisfaite structurellement par `*sync.SharedAccess` (le sous-package `skill` ne peut pas importer `sync` — cycle).
- `runLUSRV2Shadow` : sélection sous `Read` (release immédiat) → persist per-match par chunks de 3 sous `Write("lusr")` ; repos + lectures per-match sur le handle du burst (RW). 0 candidat → aucun burst.
- `runSkillRatingSteps` découpé : v1 sous Read, shadow v2 via bursts, sentinelle playerDB-only ; commentaire de classification corrigé ; `runSkillRatingStepsWithDB` (mort) supprimé.
- Callers migrés : engine, `lusr_full_recompute`, 3 cmd, wire H5, ~21 tests.

## Tests / gates

- 2 tests pérennes : `PersistsViaWriteBurst_WhenReadHandleIsReadOnly` (Read=attach READ_ONLY, Write=attach RW → persiste, watermark avance) + `ReleasesReadBeforeWriteBurst_MultiChunk` (anti-deadlock, 2 chunks).
- Audit des segments frères `shared.Read` d'engine_postsync* : aucun autre n'écrit shared (le shadow LUSR était le seul mal classé).
- `go build/vet ./...` 0 ; `go test ./...` 0 ; `go test -tags=integration -p 1` 0 (anti-ART persist/sync verts) ; `golangci-lint --new-from-rev` 0.

## ATTENTION — deploy

`push sur main = deploy prod AUTOMATIQUE`. Ce PR NE doit PAS être mergé sans GO explicite. Plan de repli post-deploy : `LEVELUP_POSTSYNC_BURST=0` (mode pinned). Pas de backfill préventif (le watermark n'ayant jamais avancé, le backlog re-rentre au premier post-sync réussi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)