### PR TITLE
fix(deploy): borner le cache du builder du daemon (incident disque 2026-07-13)

### DIFF
--- a/.ai/thought_log.md
+++ b/.ai/thought_log.md
@@ -1,3 +1,25 @@
+## [2026-07-13] INCIDENT deploy — disque VPS 100%, prod down ~15 min, cause = prune du mauvais builder
+
+**Statut** : Complété (service rétabli, fix durable posé).
+
+**Décision technique principale** : le deploy du flip H5 supported (PR #56) a échoué en
+plein build (« no space left on device », / à 100%, 0 conteneur — le script down avant
+build). Récupération : `docker builder prune -af` (46,6 Go libérés, disque à 45%) puis
+`docker compose up -d` sur l'image existante (service rétabli en ~2 min), puis rerun du
+deploy. CAUSE RACINE de l'accumulation : deploy.sh purgait avec `docker buildx prune`
+(cache du builder buildx) alors que `docker compose build` utilise le builder du DAEMON
+— deux stores distincts, l'éviction posée le 2026-06-27 ne touchait jamais le bon cache.
+Le cron hebdo (`until=168h`) épargnait les couches récentes. Fix : `docker builder prune
+-f --keep-storage=5GB` dans deploy.sh (+ buildx conservé en ceinture). Le .dockerignore
+du lot rapide (contexte 17 Go → ~Mo) réduit aussi l'alimentation du cache.
+
+**Résultats observés** : site 200, conteneurs healthy, disque 45%.
+
+**Conclusion / prochaine étape** : merger fix/deploy-prune-builder après le redeploy du
+flip ; surveiller le disque au prochain deploy.
+
+---
+
 ## [2026-07-13] Engagement H5 : gate humain E6b validé → `supported` (chantier F7, clôture)
 
 **Statut** : Complété (branche `feat/h5-engagement-supported`).

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,8 +77,13 @@ docker image prune -f
 # deploy (chaque build empile ses couches) et finit par saturer le disque du VPS
 # — incident disque 2026-06-27 : 33 Go de cache accumulé. On garde 5 Go de cache
 # récent pour des builds incrémentaux rapides ; au-delà, BuildKit évince le plus ancien.
+# PIÈGE (incident 2026-07-13, disque 100%, prod down) : `docker buildx prune` vide le
+# cache du builder BUILDX, mais `docker compose build` passe par le builder du DAEMON —
+# deux stores distincts. L'éviction ne touchait donc jamais le bon cache (46 Go
+# accumulés en 2 semaines). `docker builder prune` cible le builder du daemon.
 echo "[deploy] Bornage du cache de build Docker (keep 5GB)..."
-docker buildx prune -f --keep-storage=5GB || true
+docker builder prune -f --keep-storage=5GB || true
+docker buildx prune -f --keep-storage=1GB || true
 
 # Helper : attendre qu'un endpoint HTTP réponde (retry jusqu'à max_seconds)
 _wait_for_http() {


### PR DESCRIPTION
Incident 2026-07-13 : disque VPS 100 %, prod down pendant le deploy #56. Cause : deploy.sh purgeait via docker buildx prune, qui ne touche pas le cache du builder du daemon utilise par docker compose build (46 Go accumules). Fix : docker builder prune -f --keep-storage=5GB (+ buildx en ceinture). Recuperation d'urgence deja effectuee (46,6 Go liberes, service retabli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)